### PR TITLE
Add a note on the default performance

### DIFF
--- a/vonk/deployment/docker.rst
+++ b/vonk/deployment/docker.rst
@@ -26,7 +26,7 @@ Before you can run Vonk, you will need to pull the Docker Vonk container and req
 Running a Docker Vonk in SQLite mode
 ------------------------------------
 
-The easiest way to run a Docker Vonk container is to run Vonk in SQLite repository mode. This is also the default mode.
+The easiest and the default way to run a Docker Vonk container is to run Vonk in SQLite repository mode. Note that this is not the most performant mode - see MongoDB and SQL Server options below for that.
 
 Open your command prompt and execute this command:
 ``> docker images simplifier/vonk``


### PR DESCRIPTION
I suspect we've had at least one customer try benchmarking Vonk while running on the default sqlite server configuration, and released we make no mention of performance in the docs.

Added a blurb so people have an idea of what they're getting into.