### PR TITLE
Document limitation on implicit valuesets

### DIFF
--- a/vonk/features/validation.rst
+++ b/vonk/features/validation.rst
@@ -14,7 +14,7 @@ You can call validate on three levels:
 Besides that you can configure Vonk to validate every incoming resource and even filter on specific profiles. See the section on :ref:`feature_prevalidation`.
 In all cases, the :ref:`feature_validation_pre` is that Vonk must have access to all relevant StructureDefinitions.
 
-Validation has one :ref:`feature_validation_limitations`.
+Validation has some :ref:`feature_validation_limitations`.
 
 .. note::
 
@@ -78,5 +78,6 @@ Limitation
 -----------
 
 #. The mode parameter is not yet supported.
+#. Implicit ValueSets from a CodeSystem are not supported - create explicit ones instead.
 
 .. _`$validate`: http://www.hl7.org/implement/standards/fhir/resource-operations.html#validate

--- a/vonk/features/validation.rst
+++ b/vonk/features/validation.rst
@@ -78,6 +78,6 @@ Limitation
 -----------
 
 #. The mode parameter is not yet supported.
-#. Implicit ValueSets from a CodeSystem are not supported - create explicit ones instead.
+#. Implicit ValueSets (ones that use the .filter property) are not supported - create explicit ones instead (without the .filter property).
 
 .. _`$validate`: http://www.hl7.org/implement/standards/fhir/resource-operations.html#validate


### PR DESCRIPTION
It does not seem to take implicit valuesets defined in a codesystem into account.