### PR TITLE
Attempt to mitigate user error around no /administration

### DIFF
--- a/vonk/facade/finalizesearch.rst
+++ b/vonk/facade/finalizesearch.rst
@@ -82,7 +82,7 @@ the order of inclusion, and adds to the services. For background information, se
   The standard settings for the pipeline configuration can be found in the appsettings.default.json file, or see
   :ref:`vonk_plugins_config` for an example.
 
-  * Copy the PipelineOptions section to your appsettings.instance.json file
+  * Copy the whole PipelineOptions section to your appsettings.instance.json file (both ``/`` and ``/administration``)
   * To the ``Include`` part of the branch with ``"Path":"/"`` add your namespace, and remove the Vonk.Repository.* lines from it:
 
     ::


### PR DESCRIPTION
We were stuck at Erasmus with a confusing "resource not known" error when we were including `/` in our `.instance.json` - which was an intuitive thing for us to do because we only wanted to adjust the `/` pipeline. Didn't heed the warnings on merging JSON arrays well enough!

This is an attempt to prevent such future errors for other users.