### PR TITLE
Improving rendering of the API function lists

### DIFF
--- a/vonk/reference/programming_api/elementmodel.rst
+++ b/vonk/reference/programming_api/elementmodel.rst
@@ -21,105 +21,137 @@ For some of the more common extension methods we provide an overload on IResourc
 
 All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeExtensions``
 
-:method: ISourceNode Add(this ISourceNode original, ISourceNode newChild)
-:description: Add the ``newChild`` as a child node to the ``original``. It will be added at the end of the Children.
+.. glossary::
+  :sorted:
 
-:method: ISourceNode Add(this ISourceNode original, ITypedElement newChild)
-:description: Overload of Add(ISourceNode newChild) that lets you add an ITypedElement as new child.
+.. function:: ISourceNode Add(this ISourceNode original, ISourceNode newChild)
 
-:method: ISourceNode AddIf(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> addIf)
-:description: Add the ``newChild`` as a child node to the ``original`` if the ``addIf`` predicate on ``original`` is met. It will be added at the end of the Children.
+    Add the ``newChild`` as a child node to the ``original``. It will be added at the end of the Children.
 
-:method: ISourceNode Add(this ISourceNode original, TypedElement newChild, Func<ISourceNode, bool> addIf)
-:description: Similar to AddIf(ISourceNode newChild, Func<ISourceNode, bool> addIf) that lets you add an ITypedElement as new child.
+.. function:: ISourceNode Add(this ISourceNode original, ITypedElement newChild)
 
-:method: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild)
-:description: Add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet. It will be added at the end of the Children.
+    Overload of Add(ISourceNode newChild) that lets you add an ITypedElement as new child.
 
-:method: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> exists)
-:description: Add the ``newChild`` as a child node to the ``original`` if the ``exists`` predicate on ``original`` is not satisfied. This is like ``AddIfNotExist(ISourceNode newChild)``, but here you get to specify what 'exists' means. It will be added at the end of the Children.
+.. function:: ISourceNode AddIf(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> addIf)
 
-:method: ISourceNode AddIfNotExists(this ISourceNode original, string location, ISourceNode newChild)
-:description: Navigate to ``lcoation``. Then add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet.
+    Add the ``newChild`` as a child node to the ``original`` if the ``addIf`` predicate on ``original`` is met. It will be added at the end of the Children.
 
-:method: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists)
-:description: Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied. 
+.. function:: ISourceNode Add(this ISourceNode original, TypedElement newChild, Func<ISourceNode, bool> addIf)
 
-:method: ISourceNode AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false)
-:description: Add an annotation of type T to the ``original``. When hideExisting == true, any existing annotations of type T are not visible anymore on the returned ISourceNode.
+    Similar to AddIf(ISourceNode newChild, Func<ISourceNode, bool> addIf) that lets you add an ITypedElement as new child.
 
-:method: T GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation
-:description: Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate. 
+.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild)
+
+    Add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet. It will be added at the end of the Children.
+
+.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> exists)
+
+    Add the ``newChild`` as a child node to the ``original`` if the ``exists`` predicate on ``original`` is not satisfied. This is like ``AddIfNotExist(ISourceNode newChild)``, but here you get to specify what 'exists' means. It will be added at the end of the Children.
+
+.. function:: ISourceNode AddIfNotExists(this ISourceNode original, string location, ISourceNode newChild)
+
+    Navigate to ``lcoation``. Then add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet.
+
+.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists)
+
+    Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied. 
+
+.. function:: ISourceNode AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false)
+
+    Add an annotation of type T to the ``original``. When hideExisting == true, any existing annotations of type T are not visible anymore on the returned ISourceNode.
+
+.. function:: T GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation
+
+    Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate. 
    (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
 
-:method: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild)
-:description: Remove any nodes that have no value or children. This happens recursively: if a node has only children with empty values, it will be removed as well. This way the returned ISourceNode conforms to the invariant in the FHIR specification that an element either has a value or children.
+.. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild)
 
-:method: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location)
-:description: Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well. 
+    Remove any nodes that have no value or children. This happens recursively: if a node has only children with empty values, it will be removed as well. This way the returned ISourceNode conforms to the invariant in the FHIR specification that an element either has a value or children.
 
-:method: ISourceNode Child(this ISourceNode original, string name, int arrayIndex = 0)
-:description: Convenience method to get the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.Child("active")``
+.. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location)
 
-:method: ISourceNode ChildString(this ISourceNode original, string name, int arrayIndex = 0)
-:description: Convenience method to get the value of the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.ChildString("id")``
+    Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well. 
 
-:method: ISourceNode ForceAdd(this ISourceNode original, string addAt, ISourceNode newChild)
-:description: Add the ``newChild`` at location ``addAt``. Create the intermediate nodes if neccessary.
+.. function:: ISourceNode Child(this ISourceNode original, string name, int arrayIndex = 0)
 
-:method: ISourceNode AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
-:description: Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
+    Convenience method to get the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.Child("active")``
+
+.. function:: ISourceNode ChildString(this ISourceNode original, string name, int arrayIndex = 0)
+
+    Convenience method to get the value of the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.ChildString("id")``
+
+.. function:: ISourceNode ForceAdd(this ISourceNode original, string addAt, ISourceNode newChild)
+
+    Add the ``newChild`` at location ``addAt``. Create the intermediate nodes if neccessary.
+
+.. function:: ISourceNode AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
+
+    Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
    If none are found, add ``toAdd`` as new child.
     
-:method: ISourceNode AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
-:description:  Optimized overload of the previous method for matching on the node name.
+.. function:: ISourceNode AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
+
+     Optimized overload of the previous method for matching on the node name.
    It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
    If none are found it will add ``toAdd`` as new child node.
    
-:method: ISourceNode Remove(this ISourceNode original, string location)
-:description: Remove the node at ``location``, if any.
+.. function:: ISourceNode Remove(this ISourceNode original, string location)
+
+    Remove the node at ``location``, if any.
    If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
 
-:method: IEnumerable<ISourceNode> SelectNodes(this ISourceNode original, string fhirPath)
-:description: Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
+.. function:: IEnumerable<ISourceNode> SelectNodes(this ISourceNode original, string fhirPath)
+
+    Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
    
 
-:method: string SelectText(this ISourceNode original, string fhirPath)
-:description: Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
+.. function:: string SelectText(this ISourceNode original, string fhirPath)
+
+    Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
    
-:method: ISourceNode Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch)
-:description: Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
+.. function:: ISourceNode Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch)
 
-:method: ISourceNode Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch)
-:description: Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
+    Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
+
+.. function:: ISourceNode Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch)
+
+    Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
    If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
 
-:method: ISourceNode ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch)
-:description: Enforce that ``forcePath`` exists. Then patch the resulting node(s) with ``patch``.
+.. function:: ISourceNode ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch)
 
-:method: ISourceNode ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch)
-:description: For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
+    Enforce that ``forcePath`` exists. Then patch the resulting node(s) with ``patch``.
+
+.. function:: ISourceNode ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch)
+
+    For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
    E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
    will add request.url with value "someUrl" to every entry.
 
-:method: ISourceNode Relocate(this ISourceNode original, string newLocation)
-:description: Set ``original.Location`` to the newLocation, and update all its descendants' ``Location`` properties recursively.
+.. function:: ISourceNode Relocate(this ISourceNode original, string newLocation)
 
-:method: ISourceNode Rename(this ISourceNode original, string newName)
-:description: Set ``original.Name`` to the ``newName``.
+    Set ``original.Location`` to the newLocation, and update all its descendants' ``Location`` properties recursively.
 
-:method: ISourceNode Revalue(this ISourceNode original, string newValue)
-:description: Set ``original.Text`` to ``newValue``.
+.. function:: ISourceNode Rename(this ISourceNode original, string newName)
 
-:method: ISourceNode Revalue(this ISourceNode original, Dictionary<string, string> replacements)
-:description: ``replacements`` is a dictionary of location + newValue. On each matching location under ``original``, the value will be set to the according newValue from ``replacements``.
+    Set ``original.Name`` to the ``newName``.
 
-:method: ISourceNode AnnotateWithSourceNode(this ISourceNode original)
-:description: Add ``original`` as annotation to itself. Very specific use case.
+.. function:: ISourceNode Revalue(this ISourceNode original, string newValue)
+
+    Set ``original.Text`` to ``newValue``.
+
+.. function:: ISourceNode Revalue(this ISourceNode original, Dictionary<string, string> replacements)
+
+    ``replacements`` is a dictionary of location + newValue. On each matching location under ``original``, the value will be set to the according newValue from ``replacements``.
+
+.. function:: ISourceNode AnnotateWithSourceNode(this ISourceNode original)
+
+    Add ``original`` as annotation to itself. Very specific use case.
 
 .. _vonk_reference_api_itypedelement:
 

--- a/vonk/reference/programming_api/elementmodel.rst
+++ b/vonk/reference/programming_api/elementmodel.rst
@@ -54,7 +54,7 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 
 .. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists)
 
-    Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied. 
+    Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied.
 
 .. function:: ISourceNode AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false)
 
@@ -62,8 +62,8 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 
 .. function:: T GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation
 
-    Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate. 
-   (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
+    Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate.
+    (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
 
 .. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild)
 
@@ -71,7 +71,7 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 
 .. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location)
 
-    Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well. 
+    Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well.
 
 .. function:: ISourceNode Child(this ISourceNode original, string name, int arrayIndex = 0)
 
@@ -88,32 +88,32 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 .. function:: ISourceNode AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
 
     Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
-   If none are found, add ``toAdd`` as new child.
-    
+    If none are found, add ``toAdd`` as new child.
+
 .. function:: ISourceNode AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
 
      Optimized overload of the previous method for matching on the node name.
-   It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
-   If none are found it will add ``toAdd`` as new child node.
-   
+     It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
+     If none are found it will add ``toAdd`` as new child node.
+
 .. function:: ISourceNode Remove(this ISourceNode original, string location)
 
     Remove the node at ``location``, if any.
-   If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
+    If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
 
 .. function:: IEnumerable<ISourceNode> SelectNodes(this ISourceNode original, string fhirPath)
 
     Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
-   Use valueDateTime/valueBoolean instead of just 'value' for choice types.
-   Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
-   
+    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
+    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
+
 
 .. function:: string SelectText(this ISourceNode original, string fhirPath)
 
     Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
-   Use valueDateTime/valueBoolean instead of just 'value' for choice types.
-   Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
-   
+    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
+    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
+
 .. function:: ISourceNode Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch)
 
     Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
@@ -121,7 +121,7 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 .. function:: ISourceNode Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch)
 
     Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
-   If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
+    If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
 
 .. function:: ISourceNode ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch)
 
@@ -130,8 +130,8 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 .. function:: ISourceNode ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch)
 
     For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
-   E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
-   will add request.url with value "someUrl" to every entry.
+    E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
+    will add request.url with value "someUrl" to every entry.
 
 .. function:: ISourceNode Relocate(this ISourceNode original, string newLocation)
 
@@ -173,7 +173,7 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ITypedElemen
    Convenience overload of ``ISourceNodeExtensions.AddIfNotExists(ISourceNode, ITypedElement)``
 
 :method: ISourceNode AddIf(this ITypedElement original, ISourceNode newChild, Func<ITypedElement, bool> addIf)
-:description: Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true. 
+:description: Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true.
    Convenience overload of ``ISourceNodeExtensions.AddIf(ISourceNode, ISourceNode, Func<ISourceNode, bool>)``
 
 :method: Add(this ITypedElement original, ISourceNode newChild)

--- a/vonk/reference/programming_api/elementmodel.rst
+++ b/vonk/reference/programming_api/elementmodel.rst
@@ -19,190 +19,202 @@ All the ``ISourceNode`` extension methods can be used on ``IResource`` as well. 
 
 For some of the more common extension methods we provide an overload on IResource that does this for you, like ``IResource.Patch(...)``
 
-All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeExtensions``
+All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeExtensions``:
 
 .. glossary::
   :sorted:
 
 .. function:: Add(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
-    Add the ``newChild`` as a child node to the ``original``. It will be added at the end of the Children.
+   Add the ``newChild`` as a child node to the ``original``. It will be added at the end of the Children.
 
 .. function:: Add(this ISourceNode original, ITypedElement newChild) -> ISourceNode
 
-    Overload of Add(ISourceNode newChild) that lets you add an ITypedElement as new child.
+   Overload of Add(ISourceNode newChild) that lets you add an ITypedElement as new child.
 
 .. function:: AddIf(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> addIf) -> ISourceNode
 
-    Add the ``newChild`` as a child node to the ``original`` if the ``addIf`` predicate on ``original`` is met. It will be added at the end of the Children.
+   Add the ``newChild`` as a child node to the ``original`` if the ``addIf`` predicate on ``original`` is met. It will be added at the end of the Children.
 
 .. function:: Add(this ISourceNode original, TypedElement newChild, Func<ISourceNode, bool> addIf) -> ISourceNode
 
-    Similar to AddIf(ISourceNode newChild, Func<ISourceNode, bool> addIf) that lets you add an ITypedElement as new child.
+   Similar to AddIf(ISourceNode newChild, Func<ISourceNode, bool> addIf) that lets you add an ITypedElement as new child.
 
 .. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
-    Add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet. It will be added at the end of the Children.
+   Add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet. It will be added at the end of the Children.
 
 .. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> exists) -> ISourceNode
 
-    Add the ``newChild`` as a child node to the ``original`` if the ``exists`` predicate on ``original`` is not satisfied. This is like ``AddIfNotExist(ISourceNode newChild)``, but here you get to specify what 'exists' means. It will be added at the end of the Children.
+   Add the ``newChild`` as a child node to the ``original`` if the ``exists`` predicate on ``original`` is not satisfied. This is like ``AddIfNotExist(ISourceNode newChild)``, but here you get to specify what 'exists' means. It will be added at the end of the Children.
 
 .. function:: AddIfNotExists(this ISourceNode original, string location, ISourceNode newChild) -> ISourceNode
 
-    Navigate to ``lcoation``. Then add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet.
+   Navigate to ``lcoation``. Then add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet.
 
 .. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists) -> ISourceNode
 
-    Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied.
+   Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied.
 
 .. function:: AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false) -> ISourceNode
 
-    Add an annotation of type T to the ``original``. When hideExisting == true, any existing annotations of type T are not visible anymore on the returned ISourceNode.
+   Add an annotation of type T to the ``original``. When hideExisting == true, any existing annotations of type T are not visible anymore on the returned ISourceNode.
 
 .. function:: GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation -> T
 
-    Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate.
-    (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
+   Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate.
+   (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
 
 .. function:: RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
-    Remove any nodes that have no value or children. This happens recursively: if a node has only children with empty values, it will be removed as well. This way the returned ISourceNode conforms to the invariant in the FHIR specification that an element either has a value or children.
+   Remove any nodes that have no value or children. This happens recursively: if a node has only children with empty values, it will be removed as well. This way the returned ISourceNode conforms to the invariant in the FHIR specification that an element either has a value or children.
 
 .. function:: RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location) -> ISourceNode
 
-    Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well.
+   Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well.
 
 .. function:: Child(this ISourceNode original, string name, int arrayIndex = 0) -> ISourceNode
 
-    Convenience method to get the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.Child("active")``
+   Convenience method to get the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.Child("active")``
 
 .. function:: ChildString(this ISourceNode original, string name, int arrayIndex = 0) -> ISourceNode
 
-    Convenience method to get the value of the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.ChildString("id")``
+   Convenience method to get the value of the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.ChildString("id")``
 
 .. function:: ForceAdd(this ISourceNode original, string addAt, ISourceNode newChild) -> ISourceNode
 
-    Add the ``newChild`` at location ``addAt``. Create the intermediate nodes if neccessary.
+   Add the ``newChild`` at location ``addAt``. Create the intermediate nodes if neccessary.
 
 .. function:: AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace) -> ISourceNode
 
-    Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
-    If none are found, add ``toAdd`` as new child.
+   Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
+   If none are found, add ``toAdd`` as new child.
 
 .. function:: AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace) -> ISourceNode
 
-     Optimized overload of the previous method for matching on the node name.
-     It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
-     If none are found it will add ``toAdd`` as new child node.
+    Optimized overload of the previous method for matching on the node name.
+    It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
+    If none are found it will add ``toAdd`` as new child node.
 
 .. function:: Remove(this ISourceNode original, string location) -> ISourceNode
 
-    Remove the node at ``location``, if any.
-    If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
+   Remove the node at ``location``, if any.
+   If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
 
 .. function:: SelectNodes(this ISourceNode original, string fhirPath) -> IEnumerable<ISourceNode>
 
-    Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
-    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
-    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
+   Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
+   Use valueDateTime/valueBoolean instead of just 'value' for choice types.
+   Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
 
 
 .. function:: SelectText(this ISourceNode original, string fhirPath) -> string
 
-    Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
-    Use valueDateTime/valueBoolean instead of just 'value' for choice types.
-    Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
+   Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
+   Use valueDateTime/valueBoolean instead of just 'value' for choice types.
+   Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
 
 .. function:: Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
-    Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
+   Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
 
 .. function:: Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
-    Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
-    If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
+   Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
+   If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
 
 .. function:: ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
-    Enforce that ``forcePath`` exists. Then patch the resulting node(s) with ``patch``.
+   Enforce that ``forcePath`` exists. Then patch the resulting node(s) with ``patch``.
 
 .. function:: ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
-    For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
-    E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
-    will add request.url with value "someUrl" to every entry.
+   For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
+   E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
+   will add request.url with value "someUrl" to every entry.
 
 .. function:: Relocate(this ISourceNode original, string newLocation) -> ISourceNode
 
-    Set ``original.Location`` to the newLocation, and update all its descendants' ``Location`` properties recursively.
+   Set ``original.Location`` to the newLocation, and update all its descendants' ``Location`` properties recursively.
 
 .. function:: Rename(this ISourceNode original, string newName) -> ISourceNode
 
-    Set ``original.Name`` to the ``newName``.
+   Set ``original.Name`` to the ``newName``.
 
 .. function:: Revalue(this ISourceNode original, string newValue) -> ISourceNode
 
-    Set ``original.Text`` to ``newValue``.
+   Set ``original.Text`` to ``newValue``.
 
 .. function:: Revalue(this ISourceNode original, Dictionary<string, string> replacements) -> ISourceNode
 
-    ``replacements`` is a dictionary of location + newValue. On each matching location under ``original``, the value will be set to the according newValue from ``replacements``.
+   ``replacements`` is a dictionary of location + newValue. On each matching location under ``original``, the value will be set to the according newValue from ``replacements``.
 
 .. function:: AnnotateWithSourceNode(this ISourceNode original) -> ISourceNode
 
-    Add ``original`` as annotation to itself. Very specific use case.
+   Add ``original`` as annotation to itself. Very specific use case.
 
 .. _vonk_reference_api_itypedelement:
 
 ITypedElement manipulation
 --------------------------
 
-All the methods below are in the namespace ``Vonk.Core.ElementModel.ITypedElementExtensions``.
+All the methods below are in the namespace ``Vonk.Core.ElementModel.ITypedElementExtensions``:
 
-:method: ISourceNode Add(this ITypedElement original, ITypedElement newChild, Func<ITypedElement, bool> addIf)
-:description: Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true.
+.. function:: Add(this ITypedElement original, ITypedElement newChild, Func<ITypedElement, bool> addIf) -> ISourceNode
+
+   Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true.
    Convenience overload of ``ISourceNodeExtensions.Add(ISourceNode, ITypedElement, Func<ISourceNode, bool>)``
 
-:method: ISourceNode Add(this ITypedElement original, ITypedElement newChild)
-:description: Add ``newChild`` as child to ``original``.
+.. function:: Add(this ITypedElement original, ITypedElement newChild) -> ISourceNode
+
+   Add ``newChild`` as child to ``original``.
    Convenience overload of ``ISourceNodeExtensions.Add(ISourceNode, ITypedElement)``
 
-:method: ISourceNode AddIfNotExists(this ITypedElement original, ITypedElement newChild)
-:description: Add ``newChild`` as child to ``original`` if no child with the same name exists yet.
+.. function:: AddIfNotExists(this ITypedElement original, ITypedElement newChild) -> ISourceNode
+
+   Add ``newChild`` as child to ``original`` if no child with the same name exists yet.
    Convenience overload of ``ISourceNodeExtensions.AddIfNotExists(ISourceNode, ITypedElement)``
 
-:method: ISourceNode AddIf(this ITypedElement original, ISourceNode newChild, Func<ITypedElement, bool> addIf)
-:description: Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true.
+.. function:: AddIf(this ITypedElement original, ISourceNode newChild, Func<ITypedElement, bool> addIf) -> ISourceNode
+
+   Add ``newChild`` as child to ``original`` if ``addIf`` on ``original`` evaluates to true.
    Convenience overload of ``ISourceNodeExtensions.AddIf(ISourceNode, ISourceNode, Func<ISourceNode, bool>)``
 
 :method: Add(this ITypedElement original, ISourceNode newChild)
-:description: Add ``newChild`` as child to ``original``.
+   Add ``newChild`` as child to ``original``.
 
 :method: AddIfNotExists(this ITypedElement original, ISourceNode newChild)
-:description: Add ``newChild`` as child to ``original`` if no child with the same name exists yet.
+   Add ``newChild`` as child to ``original`` if no child with the same name exists yet.
    Convenience overload of ``AddIfNotExists(ITypedElement, ITypedElement)``
 
-:method: ITypedElement Cache(this ITypedElement original)
-:description: Prevent recalculation of the Children upon every access.
+.. function:: Cache(this ITypedElement original) -> ITypedElement
 
-:method: ITypedElement Child(this ITypedElement element, string name, int arrayIndex = 0)
-:description: Returns n-th child with the specified ``name``, if any.
+   Prevent recalculation of the Children upon every access.
 
-:method: string ChildString(this ITypedElement element, string name, int arrayIndex = 0)
-:description: Returns the value of the n-th child with the specified ``name`` as string, if any.
+.. function:: Child(this ITypedElement element, string name, int arrayIndex = 0) -> ITypedElement
 
-:method: IStructureDefinitionSummary DefinitionSummary(this ITypedElement element, IStructureDefinitionSummaryProvider provider)
-:description: Returns the summary for the actual type of the element. Especially useful if the element is of a choicetype.
+   Returns n-th child with the specified ``name``, if any.
 
-:method: ITypedElement AddParent(this ITypedElement element)
-:description: Add ``Vonk.Core.ElementModel.IParentProvider`` annotations to ``element`` and its descendants.
+.. function:: ChildString(this ITypedElement element, string name, int arrayIndex = 0) -> string
 
-:method: ITypedElement GetParent(this ITypedElement element)
-:description: Get the parent of this element, through the ``Vonk.Core.ElementModel.IParentProvider`` annotation (if present).
+   Returns the value of the n-th child with the specified ``name`` as string, if any.
 
-:method: ITypedElement AddTreePath(this ITypedElement element)
-:description: Add the ``Vonk.Core.ElementModel.ITreePathGenerator`` annotation. TreePath is the Location without any indexes (no [n] at the end).
+.. function:: DefinitionSummary(this ITypedElement element, IStructureDefinitionSummaryProvider provider) -> IStructureDefinitionSummary
 
-:method: string GetTreePath(this ITypedElement element)
-:description: Get the value of the ``Vonk.Core.ElementModel.ITreePathGenerator`` annotation, if present. TreePath is the Location without any indexes (no [n] at the end).
+   Returns the summary for the actual type of the element. Especially useful if the element is of a choicetype.
+
+.. function:: AddParent(this ITypedElement element) -> ITypedElement
+
+   Add ``Vonk.Core.ElementModel.IParentProvider`` annotations to ``element`` and its descendants.
+
+.. function:: GetParent(this ITypedElement element) -> ITypedElement
+
+   Get the parent of this element, through the ``Vonk.Core.ElementModel.IParentProvider`` annotation (if present).
+
+.. function:: AddTreePath(this ITypedElement element) -> ITypedElement
+
+   Add the ``Vonk.Core.ElementModel.ITreePathGenerator`` annotation. TreePath is the Location without any indexes (no [n] at the end).
+
+.. function:: GetTreePath(this ITypedElement element) -> string
+
+   Get the value of the ``Vonk.Core.ElementModel.ITreePathGenerator`` annotation, if present. TreePath is the Location without any indexes (no [n] at the end).

--- a/vonk/reference/programming_api/elementmodel.rst
+++ b/vonk/reference/programming_api/elementmodel.rst
@@ -24,132 +24,132 @@ All the methods below are in the namespace ``Vonk.Core.ElementModel.ISourceNodeE
 .. glossary::
   :sorted:
 
-.. function:: ISourceNode Add(this ISourceNode original, ISourceNode newChild)
+.. function:: Add(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
     Add the ``newChild`` as a child node to the ``original``. It will be added at the end of the Children.
 
-.. function:: ISourceNode Add(this ISourceNode original, ITypedElement newChild)
+.. function:: Add(this ISourceNode original, ITypedElement newChild) -> ISourceNode
 
     Overload of Add(ISourceNode newChild) that lets you add an ITypedElement as new child.
 
-.. function:: ISourceNode AddIf(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> addIf)
+.. function:: AddIf(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> addIf) -> ISourceNode
 
     Add the ``newChild`` as a child node to the ``original`` if the ``addIf`` predicate on ``original`` is met. It will be added at the end of the Children.
 
-.. function:: ISourceNode Add(this ISourceNode original, TypedElement newChild, Func<ISourceNode, bool> addIf)
+.. function:: Add(this ISourceNode original, TypedElement newChild, Func<ISourceNode, bool> addIf) -> ISourceNode
 
     Similar to AddIf(ISourceNode newChild, Func<ISourceNode, bool> addIf) that lets you add an ITypedElement as new child.
 
-.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild)
+.. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
     Add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet. It will be added at the end of the Children.
 
-.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> exists)
+.. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild, Func<ISourceNode, bool> exists) -> ISourceNode
 
     Add the ``newChild`` as a child node to the ``original`` if the ``exists`` predicate on ``original`` is not satisfied. This is like ``AddIfNotExist(ISourceNode newChild)``, but here you get to specify what 'exists' means. It will be added at the end of the Children.
 
-.. function:: ISourceNode AddIfNotExists(this ISourceNode original, string location, ISourceNode newChild)
+.. function:: AddIfNotExists(this ISourceNode original, string location, ISourceNode newChild) -> ISourceNode
 
     Navigate to ``lcoation``. Then add the ``newChild`` as a child node to the ``original`` if there is no child with the same name yet.
 
-.. function:: ISourceNode AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists)
+.. function:: AddIfNotExists(this ISourceNode original, ISourceNode newChild, string location, Func<ISourceNode, bool> exists) -> ISourceNode
 
     Navigate to ``location``. Then add the ``newChild`` as a child node if the ``exists`` predicate on the current node is not satisfied.
 
-.. function:: ISourceNode AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false)
+.. function:: AnnotateWith<T>(this ISourceNode original, T annotation, bool hideExisting = false) -> ISourceNode
 
     Add an annotation of type T to the ``original``. When hideExisting == true, any existing annotations of type T are not visible anymore on the returned ISourceNode.
 
-.. function:: T GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation
+.. function:: GetBoundAnnotation<T>(this ISourceNode original, ) where T : class, IBoundAnnotation -> T
 
     Retrieve an annotation that is bound directly to ``original``, not to any of the nodes it may decorate.
     (ISourceNode is immutable, to changes are usually a pile of wrappers around the ``original`` SourceNode, and each of the wrappers can add / replace annotations.)
 
-.. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild)
+.. function:: RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild) -> ISourceNode
 
     Remove any nodes that have no value or children. This happens recursively: if a node has only children with empty values, it will be removed as well. This way the returned ISourceNode conforms to the invariant in the FHIR specification that an element either has a value or children.
 
-.. function:: ISourceNode RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location)
+.. function:: RemoveEmptyNodes(this ISourceNode original, ISourceNode newChild, string location) -> ISourceNode
 
     Remove any nodes that have no value or children, from the specified ``location`` downwards. This happens recursively: if a node has only children with empty values, it will be removed as well.
 
-.. function:: ISourceNode Child(this ISourceNode original, string name, int arrayIndex = 0)
+.. function:: Child(this ISourceNode original, string name, int arrayIndex = 0) -> ISourceNode
 
     Convenience method to get the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.Child("active")``
 
-.. function:: ISourceNode ChildString(this ISourceNode original, string name, int arrayIndex = 0)
+.. function:: ChildString(this ISourceNode original, string name, int arrayIndex = 0) -> ISourceNode
 
     Convenience method to get the value of the child with name ``name`` at position ``arrayIndex``. Usually used to get a child of which you know there is only one: ``patientNode.ChildString("id")``
 
-.. function:: ISourceNode ForceAdd(this ISourceNode original, string addAt, ISourceNode newChild)
+.. function:: ForceAdd(this ISourceNode original, string addAt, ISourceNode newChild) -> ISourceNode
 
     Add the ``newChild`` at location ``addAt``. Create the intermediate nodes if neccessary.
 
-.. function:: ISourceNode AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
+.. function:: AddOrReplace(this ISourceNode original, Func<ISourceNode, bool> match, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace) -> ISourceNode
 
     Find any child nodes of ``original`` that match the ``match`` predicate. Apply ``replace`` to them.
     If none are found, add ``toAdd`` as new child.
 
-.. function:: ISourceNode AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace)
+.. function:: AddOrReplace(this ISourceNode original, ISourceNode toAdd, Func<ISourceNode, ISourceNode> replace) -> ISourceNode
 
      Optimized overload of the previous method for matching on the node name.
      It will perform ``replace`` on any child node of ``original`` with the same name as ``toAdd``.
      If none are found it will add ``toAdd`` as new child node.
 
-.. function:: ISourceNode Remove(this ISourceNode original, string location)
+.. function:: Remove(this ISourceNode original, string location) -> ISourceNode
 
     Remove the node at ``location``, if any.
     If that results in parent nodes becoming empty (no Text, no Children), those are removed as well.
 
-.. function:: IEnumerable<ISourceNode> SelectNodes(this ISourceNode original, string fhirPath)
+.. function:: SelectNodes(this ISourceNode original, string fhirPath) -> IEnumerable<ISourceNode>
 
     Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. It will return the matching nodes.
     Use valueDateTime/valueBoolean instead of just 'value' for choice types.
     Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
 
 
-.. function:: string SelectText(this ISourceNode original, string fhirPath)
+.. function:: SelectText(this ISourceNode original, string fhirPath) -> string
 
     Run ``fhirPath`` over the ``original``, but with the limitations of untyped nodes. Returns the ``Text`` of the first matching node.
     Use valueDateTime/valueBoolean instead of just 'value' for choice types.
     Only use this method if you are familiar with the differences in the naming of nodes between ISourceNode and ITypedElement.
 
-.. function:: ISourceNode Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch)
+.. function:: Patch(this ISourceNode original, string location, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
     Find any nodes at ``location`` and apply ``patch`` to them. For ``patch`` you can use other methods listed here like ``Rename``, ``Add`` or ``Revalue``. ``location`` is evaluated as a fhirpath statement, with the limitations of untyped nodes.
 
-.. function:: ISourceNode Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch)
+.. function:: Patch(this ISourceNode original, string[] locations, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
     Find any nodes having one of the ``locations`` as their Location and apply ``patch`` to them.
     If you don't know exact locations, use ``original.Patch(location, patch)``, see above.
 
-.. function:: ISourceNode ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch)
+.. function:: ForcePatch(this ISourceNode original, string forcePath, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
     Enforce that ``forcePath`` exists. Then patch the resulting node(s) with ``patch``.
 
-.. function:: ISourceNode ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch)
+.. function:: ForcePatchAt(this ISourceNode original, string fromLocation, string forcePath, Func<ISourceNode, ISourceNode> patch) -> ISourceNode
 
     For each node matching the ``fromLocation``: enforce that ``fromLocation.forcePath`` exists, then patch the resulting node(s) with ``patch``.
     E.g. someBundle.ForcePatchAt("entry", "request", node => node.Add(SourceNode.Valued("url", "someUrl"))
     will add request.url with value "someUrl" to every entry.
 
-.. function:: ISourceNode Relocate(this ISourceNode original, string newLocation)
+.. function:: Relocate(this ISourceNode original, string newLocation) -> ISourceNode
 
     Set ``original.Location`` to the newLocation, and update all its descendants' ``Location`` properties recursively.
 
-.. function:: ISourceNode Rename(this ISourceNode original, string newName)
+.. function:: Rename(this ISourceNode original, string newName) -> ISourceNode
 
     Set ``original.Name`` to the ``newName``.
 
-.. function:: ISourceNode Revalue(this ISourceNode original, string newValue)
+.. function:: Revalue(this ISourceNode original, string newValue) -> ISourceNode
 
     Set ``original.Text`` to ``newValue``.
 
-.. function:: ISourceNode Revalue(this ISourceNode original, Dictionary<string, string> replacements)
+.. function:: Revalue(this ISourceNode original, Dictionary<string, string> replacements) -> ISourceNode
 
     ``replacements`` is a dictionary of location + newValue. On each matching location under ``original``, the value will be set to the according newValue from ``replacements``.
 
-.. function:: ISourceNode AnnotateWithSourceNode(this ISourceNode original)
+.. function:: AnnotateWithSourceNode(this ISourceNode original) -> ISourceNode
 
     Add ``original`` as annotation to itself. Very specific use case.
 

--- a/vonk/reference/programming_api/interactionhandling.rst
+++ b/vonk/reference/programming_api/interactionhandling.rst
@@ -84,17 +84,21 @@ If you have a very specific filter that is not covered by these methods, you can
 IApplicationBuilder extension methods
 -------------------------------------
 
-:method: ``IApplicationBuilder UseVonkInteraction<TService>(this IApplicationBuilder app, Expression<Action<<TService, IVonkContext>> handler, OperationType operationType = OperationType.Handler)``
-:description: Handle the request with the ``handler`` method when the request matches the ``InteractionHandler`` attribute on the ``handler`` method. The ``OperationType`` may also specify ``PreHandler`` or ``PostHandler``. If you need to do anything lengthy (I/O, computation), use the Async variant of this method.
+.. function:: UseVonkInteraction<TService>(this IApplicationBuilder app, Expression<Action<<TService, IVonkContext>> handler, OperationType operationType = OperationType.Handler) -> IApplicationBuilder
 
-:method: ``IApplicationBuilder UseVonkInteractionAsync<TService>(this IApplicationBuilder app, Expression<Func<TService, IVonkContext, T.Task>> handler, OperationType operationType = OperationType.Handler)``
-:description: Handle the request with the asynchronous ``handler`` method when the request matches the ``InteractionHandler`` attribute on the ``handler`` method. The ``OperationType`` may also specify ``PreHandler`` or ``PostHandler``. 
+   Handle the request with the ``handler`` method when the request matches the ``InteractionHandler`` attribute on the ``handler`` method. The ``OperationType`` may also specify ``PreHandler`` or ``PostHandler``. If you need to do anything lengthy (I/O, computation), use the Async variant of this method.
 
-:method: ``VonkAppBuilder OnInteraction(this IApplicationBuilder app, VonkInteraction interaction)``
-:description: Used for fluent configuration of middleware. This is one of two methods to enter the ``VonkAppBuilder``, see :ref:`vonk_vonkappbuilder`. It requires you to choose an interaction to act on. If you need your services to act on every interaction, choose ``VonkInteraction.all``.
+.. function:: UseVonkInteractionAsync<TService>(this IApplicationBuilder app, Expression<Func<TService, IVonkContext, T.Task>> handler, OperationType operationType = OperationType.Handler) -> IApplicationBuilder
 
-:method: ``VonkAppBuilder OnCustomInteraction(this IApplicationBuilder app, VonkInteraction interaction, string custom)``
-:description: Used for fluent configuration of middleware. This is one of two methods to enter the ``VonkAppBuilder``, see :ref:`vonk_vonkappbuilder`. It requires you to choose an interaction to act on. This should be one of the ``VonkInteraction.all_custom`` interactions. ``custom`` is the name of the custom interaction to act on, without the preceding '$'.
+   Handle the request with the asynchronous ``handler`` method when the request matches the ``InteractionHandler`` attribute on the ``handler`` method. The ``OperationType`` may also specify ``PreHandler`` or ``PostHandler``.
+
+.. function:: OnInteraction(this IApplicationBuilder app, VonkInteraction interaction) -> VonkAppBuilder
+
+   Used for fluent configuration of middleware. This is one of two methods to enter the ``VonkAppBuilder``, see :ref:`vonk_vonkappbuilder`. It requires you to choose an interaction to act on. If you need your services to act on every interaction, choose ``VonkInteraction.all``.
+
+.. function:: OnCustomInteraction(this IApplicationBuilder app, VonkInteraction interaction, string custom) -> VonkAppBuilder
+
+   Used for fluent configuration of middleware. This is one of two methods to enter the ``VonkAppBuilder``, see :ref:`vonk_vonkappbuilder`. It requires you to choose an interaction to act on. This should be one of the ``VonkInteraction.all_custom`` interactions. ``custom`` is the name of the custom interaction to act on, without the preceding '$'.
 
 .. _vonk_vonkappbuilder:
 
@@ -103,35 +107,46 @@ VonkAppBuilder extension methods
 
 ``VonkAppBuilder`` is used to fluently configure your middleware. It has methods to filter the requests that your middleware should respond to. Then it has a couple of ``*Handle...`` methods to transform your service into middleware for the pipeline, and return to the IApplicationBuilder interface.
 
-:method: ``VonkAppBuilder AndInteraction(this VonkAppBuilder app, VonkInteraction interaction)``
-:description: Specify an interaction to act on.
+.. function:: AndInteraction(this VonkAppBuilder app, VonkInteraction interaction) -> VonkAppBuilder
 
-:method: ``VonkAppBuilder AndResourceTypes(this VonkAppBuilder app, params string[] resourceTypes)``
-:description: Specify the resourcetypes to act on.
+   Specify an interaction to act on.
 
-:method: ``VonkAppBuilder AndStatusCodes(this VonkAppBuilder app, params int[] statusCodes)``
-:description: Specify the statuscode(s) of the response to act on. This is mainly useful for posthandlers.
+.. function:: AndResourceTypes(this VonkAppBuilder app, params string[] resourceTypes) -> VonkAppBuilder
 
-:method: ``VonkAppBuilder AndMethod(this VonkAppBuilder app, string method)``
-:description: Specify the http method (GET, PUT, etc) to act on.
+   Specify the resourcetypes to act on.
 
-:method: ``VonkAppBuilder AndInformationModel(this VonkAppBuilder app, string model)``
-:description: If your service can only act on one FHIR version, specify it with this method. Common values for ``model`` are ``VonkConstants.Model.FhirR3`` and ``VonkConstants.Model.FhirR4``.
+.. function:: AndStatusCodes(this VonkAppBuilder app, params int[] statusCodes) -> VonkAppBuilder
 
-:method: ``IApplicationBuilder PreHandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> preHandler)``
-:description: Mark the ``preHandler`` method as a prehandler, so it will act on the IVonkContext and send it further down the pipeline.
+   Specify the statuscode(s) of the response to act on. This is mainly useful for posthandlers.
 
-:method: ``IApplicationBuilder PreHandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> preHandler)``
-:description: Synchronous version of ``PreHandleAsyncWith`` for synchronous ``preHandler`` methods.
+.. function:: AndMethod(this VonkAppBuilder app, string method) -> VonkAppBuilder
 
-:method: ``IApplicationBuilder HandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> handler)``
-:description: Mark the ``handler`` method as a hanlder, so it will act on the IVonkContext, provide a response and end the pipeline for the request.
+   Specify the http method (GET, PUT, etc) to act on.
 
-:method: ``HandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> handler)``
-:description: Synchronous version of ``HandleAsyncWith`` for synchronous ``handler`` methods.
+.. function:: AndInformationModel(this VonkAppBuilder app, string model) -> VonkAppBuilder
 
-:method: ``IApplicationBuilder PostHandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> postHandler)``
-:description: Mark the ``postHandler`` method as a posthandler, so it will pass on the IVonkContext to the rest of the pipeline, and on the way back through the pipeline inspect or modify the response.
+   If your service can only act on one FHIR version, specify it with this method. Common values for ``model`` are ``VonkConstants.Model.FhirR3`` and ``VonkConstants.Model.FhirR4``.
 
-:method: ``IApplicationBuilder PostHandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> postHandler)``
-:description: Synchronous version of ``PostHandleAsyncWith`` for synchronous ``postHandler`` methods.
+.. function:: PreHandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> preHandler) -> IApplicationBuilder
+
+   Mark the ``preHandler`` method as a prehandler, so it will act on the IVonkContext and send it further down the pipeline.
+
+.. function:: PreHandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> preHandler) -> IApplicationBuilder
+
+   Synchronous version of ``PreHandleAsyncWith`` for synchronous ``preHandler`` methods.
+
+.. function:: HandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> handler) -> IApplicationBuilder
+
+   Mark the ``handler`` method as a hanlder, so it will act on the IVonkContext, provide a response and end the pipeline for the request.
+
+.. function:: HandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> handler)
+
+   Synchronous version of ``HandleAsyncWith`` for synchronous ``handler`` methods.
+
+.. function:: PostHandleAsyncWith<TService>(this VonkAppBuilder app, Expression<Func<TService, IVonkContext, T.Task>> postHandler) -> IApplicationBuilder
+
+   Mark the ``postHandler`` method as a posthandler, so it will pass on the IVonkContext to the rest of the pipeline, and on the way back through the pipeline inspect or modify the response.
+
+.. function:: PostHandleWith<TService>(this VonkAppBuilder app, Expression<Action<TService, IVonkContext>> postHandler) -> IApplicationBuilder
+
+   Synchronous version of ``PostHandleAsyncWith`` for synchronous ``postHandler`` methods.


### PR DESCRIPTION
Before - difficult to scan for a function name:

![image](https://user-images.githubusercontent.com/110988/70529907-f41c0780-1b51-11ea-8094-93659579cc16.png)

Now - much easier: 

![image](https://user-images.githubusercontent.com/110988/70529913-fa11e880-1b51-11ea-8408-b2b341d9408f.png)

It's not perfect. If `<thing>` is used, parameters aren't highlighted right:

![image](https://user-images.githubusercontent.com/110988/70530072-596ff880-1b52-11ea-9cdf-0201cabd1bed.png)

I've investigated the use of https://github.com/djungelorm/sphinx-csharp to work around this, but unfortunately [it's not ready](https://github.com/djungelorm/sphinx-csharp/issues/7). Nonetheless, this rendering is better than the table before!