### PR TITLE
Clarify nested element locations for search params

### DIFF
--- a/vonk/configuration/appsettings.rst
+++ b/vonk/configuration/appsettings.rst
@@ -346,6 +346,7 @@ Be aware that:
 
 * support for _type and _id cannot be disabled
 * the Administration API requires support for the 'url' SearchParameter on the conformance resourcetypes
+* this uses the search parameter names, not the path within the resource - so for example to specify 	`Patient.address.postalCode <http://hl7.org/fhir/R4/patient.html#search>`_ as a supported parameter, you'd use ``"Patient.address-postalcode"``.
 
 .. _disable_interactions:
 

--- a/vonk/configuration/appsettings.rst
+++ b/vonk/configuration/appsettings.rst
@@ -346,7 +346,7 @@ Be aware that:
 
 * support for _type and _id cannot be disabled
 * the Administration API requires support for the 'url' SearchParameter on the conformance resourcetypes
-* this uses the search parameter names, not the path within the resource - so for example to specify `Patient.address.postalCode <http://hl7.org/fhir/R4/patient.html#search>`_ as a supported parameter, you'd use ``"Patient.address-postalcode"``.
+* this uses the search parameter names, not the path within the resource - so for example to specify `Patient.address.postalCode <http://hl7.org/fhir/R4/patient.html#search>`_ as a supported location, you'd use ``"Patient.address-postalcode"``.
 
 .. _disable_interactions:
 

--- a/vonk/configuration/appsettings.rst
+++ b/vonk/configuration/appsettings.rst
@@ -346,7 +346,7 @@ Be aware that:
 
 * support for _type and _id cannot be disabled
 * the Administration API requires support for the 'url' SearchParameter on the conformance resourcetypes
-* this uses the search parameter names, not the path within the resource - so for example to specify 	`Patient.address.postalCode <http://hl7.org/fhir/R4/patient.html#search>`_ as a supported parameter, you'd use ``"Patient.address-postalcode"``.
+* this uses the search parameter names, not the path within the resource - so for example to specify `Patient.address.postalCode <http://hl7.org/fhir/R4/patient.html#search>`_ as a supported parameter, you'd use ``"Patient.address-postalcode"``.
 
 .. _disable_interactions:
 


### PR DESCRIPTION
An implementer was a bit unsure about the `SearchParameters` field and listed the full path to the element in it - which isn't quite correct, as it uses the search parameters name instead.

Clarify documentation to remove this ambiguity for FHIR newbies :)