### PR TITLE
Clarify where Application Insights Telemetry comes from

### DIFF
--- a/vonk/configuration/logsettings.rst
+++ b/vonk/configuration/logsettings.rst
@@ -164,7 +164,7 @@ If you do so you probably don't want all this detail in your console sink, so yo
 
 Azure Application Insights
 --------------------------
-Vonk can also log to Azure Application Insights. What you need to do:
+Vonk can also log to Azure Application Insights ("Application Insights Telemetry"). What you need to do:
 
 #. Create an Application Insights instance on Azure.
 #. Get the InstrumentationKey from the Properties blade of this instance.


### PR DESCRIPTION
It's pretty spammy in Visual Studio Code and an immediate search for "Application Insights Telemetry" doesn't find it - add in the keywords so anyone searching will find it.