### PR TITLE
Document how to see SMART authorization errors

### DIFF
--- a/vonk/features/accesscontrol.rst
+++ b/vonk/features/accesscontrol.rst
@@ -296,3 +296,4 @@ You can test it using a dummy Identity Provider and Postman as a REST client. Pl
 .. _Patient CompartmentDefinition: http://www.hl7.org/implement/standards/fhir/compartmentdefinition-patient.html
 .. _ASP.NET Core Identity: https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity
 
+You might also find it useful to enable more extensive authorization failure logging - Vonk defaults to a secure setup and does not show what exactly went wrong during authorization. To do so, set the ``ASPNETCORE_ENVIRONMENT`` environment variable to ``Development``.


### PR DESCRIPTION
Document how to see SMART authorization errors - without this, it is pretty tough to debug what is going wrong.